### PR TITLE
GitHub CI: Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/fox32asm-unstable-linux.yml
+++ b/.github/workflows/fox32asm-unstable-linux.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -23,7 +23,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: fox32asm
           path: target/release/fox32asm

--- a/.github/workflows/fox32asm-unstable-windows.yml
+++ b/.github/workflows/fox32asm-unstable-windows.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -23,7 +23,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: fox32asm.exe
           path: target/release/fox32asm.exe


### PR DESCRIPTION
v2 is deprecated and causes a warning on the Actions page.