### PR TITLE
Don't parse _123 as a decimal number

### DIFF
--- a/src/fox32.pest
+++ b/src/fox32.pest
@@ -148,8 +148,8 @@ body_bin       = @{ (ASCII_BIN_DIGIT | "_")+ }
 immediate_hex  = ${ "0x" ~ body_hex }
 body_hex       = @{ (ASCII_HEX_DIGIT | "_")+ }
 
-immediate_dec  = ${ body_dec }
-body_dec       = @{ (ASCII_DIGIT | "_")+ }
+immediate_dec  = ${ ASCII_DIGIT ~ body_dec }
+body_dec       = @{ (ASCII_DIGIT | "_")* }
 
 immediate_char = ${ "'" ~ body_char ~ "'" }
 body_char      = @{ '\x00'..'\x7F' }

--- a/src/main.rs
+++ b/src/main.rs
@@ -805,8 +805,8 @@ fn parse_operand(mut pair: pest::iterators::Pair<Rule>, is_pointer: bool) -> Ast
                     immediate_to_astnode(immediate, size, is_pointer)
                 }
                 Rule::immediate_dec => {
-                    let body_dec_str = operand_value_pair.into_inner().next().unwrap().as_str();
-                    let immediate = remove_underscores(body_dec_str).parse::<u32>().unwrap();
+                    let dec_str = operand_value_pair.as_span().as_str();
+                    let immediate = remove_underscores(dec_str).parse::<u32>().unwrap();
                     immediate_to_astnode(immediate, size, is_pointer)
                 }
                 Rule::immediate_char => {


### PR DESCRIPTION
Instead require that decimal numbers start with a digit.

This fixes the detection of things like _L4 and _4 as labels.

Fixes #11 