### PR TITLE
fix: allow '.' in label name characters

### DIFF
--- a/src/fox32.pest
+++ b/src/fox32.pest
@@ -46,7 +46,7 @@ label_kind = {
     label_global
 }
 label_name = @{ label_name_chars+ }
-label_name_chars = @{ ASCII_ALPHANUMERIC | "_" }
+label_name_chars = @{ ASCII_ALPHANUMERIC | "_" | "." }
 label_external = { "extern" }
 label_global   = { "global" }
 


### PR DESCRIPTION
```
running 6 tests
test tests::allocate ... ok
test tests::cputest ... ok
test tests::hello_world ... ok
test tests::multitasking ... ok
test tests::robotfindskitten ... ok
test tests::tcc ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
```
Closes #18 

