### PR TITLE
Label sizes in bit opcodes

### DIFF
--- a/src/instr.rs
+++ b/src/instr.rs
@@ -326,6 +326,8 @@ pub fn parse_instruction_two(
         "sla" | "sra" | "srl" | "rol" | "ror" | "bse" | "bcl" | "bts" => {
             if let Some(value) = node_value(&rhs) {
                 rhs = AstNode::Immediate8(value as u8);
+            } else if let AstNode::LabelOperand { name, size: _, is_relative } = rhs {
+                rhs = AstNode::LabelOperand { name, size: Size::Byte, is_relative };
             }
         }
         _ => (),


### PR DESCRIPTION
When the immediate source argument to `sla`, `sra`, `srl`, `ror`, `rol`, `bcl`, `bse` or `bts` is a label its size is now correctly coerced to a byte.