### PR TITLE
allow multiple operands for data.8/.16/.32 statements

### DIFF
--- a/src/fox32.pest
+++ b/src/fox32.pest
@@ -30,9 +30,9 @@ data = {
     data_strz |
     data_fill
 }
-data_byte = { "data.8" ~ operand_value }
-data_half = { "data.16" ~ operand_value }
-data_word = { "data.32" ~ operand_value }
+data_byte = { "data.8" ~ operand_value ~ ("," ~ operand_value)* }
+data_half = { "data.16" ~ operand_value ~ ("," ~ operand_value)* }
+data_word = { "data.32" ~ operand_value ~ ("," ~ operand_value)* }
 data_str  = { "data.str" ~ immediate_str }
 data_strz = { "data.strz" ~ immediate_str }
 data_fill = { "data.fill" ~ operand_value ~ "," ~ operand_value }

--- a/src/parser/data.rs
+++ b/src/parser/data.rs
@@ -123,45 +123,45 @@ pub fn parse_data(pair: pest::iterators::Pair<Rule>) -> AstNode {
     //println!("{:#?}", pair);
     *CURRENT_SIZE.lock().expect(POISONED_MUTEX_ERR) = Size::Word;
     match pair.as_rule() {
-        Rule::data_byte => match parse_operand(pair.into_inner().next().unwrap(), false) {
-            AstNode::Immediate32(half) => AstNode::DataByte(half as u8),
-            AstNode::LabelOperand {
-                name,
-                size: _,
-                is_relative,
-            } => AstNode::LabelOperand {
-                name,
-                size: Size::Byte,
-                is_relative,
-            },
-            _ => unreachable!(),
-        },
-        Rule::data_half => match parse_operand(pair.into_inner().next().unwrap(), false) {
-            AstNode::Immediate32(half) => AstNode::DataHalf(half as u16),
-            AstNode::LabelOperand {
-                name,
-                size: _,
-                is_relative,
-            } => AstNode::LabelOperand {
-                name,
-                size: Size::Half,
-                is_relative,
-            },
-            _ => unreachable!(),
-        },
-        Rule::data_word => match parse_operand(pair.into_inner().next().unwrap(), false) {
-            AstNode::Immediate32(word) => AstNode::DataWord(word),
-            AstNode::LabelOperand {
-                name,
-                size: _,
-                is_relative,
-            } => AstNode::LabelOperand {
-                name,
-                size: Size::Word,
-                is_relative,
-            },
-            _ => unreachable!(),
-        },
+        Rule::data_byte => {
+            let nodes = pair
+                .into_inner()
+                .map(|operand_pair| match parse_operand(operand_pair, false) {
+                    AstNode::Immediate32(byte) => AstNode::DataByte(byte as u8),
+                    AstNode::LabelOperand { name, size: _, is_relative } => {
+                        AstNode::LabelOperand { name, size: Size::Byte, is_relative }
+                    }
+                    _ => unreachable!(),
+                })
+                .collect();
+            AstNode::DataMulti(nodes)
+        }
+        Rule::data_half => {
+            let nodes = pair
+                .into_inner()
+                .map(|operand_pair| match parse_operand(operand_pair, false) {
+                    AstNode::Immediate32(half) => AstNode::DataHalf(half as u16),
+                    AstNode::LabelOperand { name, size: _, is_relative } => {
+                        AstNode::LabelOperand { name, size: Size::Half, is_relative }
+                    }
+                    _ => unreachable!(),
+                })
+                .collect();
+            AstNode::DataMulti(nodes)
+        }
+        Rule::data_word => {
+            let nodes = pair
+                .into_inner()
+                .map(|operand_pair| match parse_operand(operand_pair, false) {
+                    AstNode::Immediate32(word) => AstNode::DataWord(word),
+                    AstNode::LabelOperand { name, size: _, is_relative } => {
+                        AstNode::LabelOperand { name, size: Size::Word, is_relative }
+                    }
+                    _ => unreachable!(),
+                })
+                .collect();
+            AstNode::DataMulti(nodes)
+        }
         Rule::data_str => {
             let string = pair
                 .into_inner()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -71,6 +71,7 @@ pub enum AstNode {
         value: u8,
         size: SizeOrLabelName,
     },
+    DataMulti(Vec<AstNode>),
 
     IncludedBinary(Vec<u8>),
 
@@ -194,7 +195,14 @@ pub fn parse(source: &str) -> Result<Vec<AstNode>, Box<Error<Rule>>> {
     for pair in pairs.peek().unwrap().into_inner() {
         match pair.as_rule() {
             Rule::EOI => break,
-            _ => ast.push(build_ast_from_expression(pair)),
+            _ => {
+                let node = build_ast_from_expression(pair);
+                if let AstNode::DataMulti(nodes) = node {
+                    ast.extend(nodes);
+                } else {
+                    ast.push(node);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
~~now i don't know about you but i do not quite like `data.8 0x00 data.8 0x00 data.8 0x00` so it can now be expressed as `data.8 0x00, 0x00, 0x00`~~
nvm it's broken LOL